### PR TITLE
fix cases where the version is not semver and throws an error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,7 +11,14 @@ function diff(oldLock, newLock) {
 
   Object.entries(newLock.dependencies).forEach(([name, { version }]) => {
     if (changes[name]) {
-      if (semver.eq(changes[name][0], version)) {
+      let semverEq;
+      try {
+        semverEq = semver.eq(changes[name][0], version)
+      } catch (e) {
+        // sometimes git urls are used rather than semver
+        semverEq = changes[name][0] === version;
+      }
+      if (semverEq) {
         delete changes[name];
       } else {
         changes[name] = [changes[name][0], version];


### PR DESCRIPTION
We have some packages that are installed directly from a branch in github, this throws the following error from the semver package. I added a try-catch and basic comparison to at least have the script work in these edge cases.

```sh
.../node_modules/lock-diff/node_modules/semver/semver.js:332
    throw new TypeError('Invalid Version: ' + version)
    ^

TypeError: Invalid Version: git+ssh://git@github.com/tablecheck/chroma.js.git#08fa6d953fa67c03062ae3e2bb68c21c255a15ed
    at new SemVer (.../node_modules/lock-diff/node_modules/semver/semver.js:332:11)
    at compare (.../node_modules/lock-diff/node_modules/semver/semver.js:647:10)
    at Function.eq (.../node_modules/lock-diff/node_modules/semver/semver.js:693:10)
    at .../node_modules/lock-diff/lib/index.js:14:18
    at Array.forEach (<anonymous>)
    at diff (.../node_modules/lock-diff/lib/index.js:12:40)
    at Command.<anonymous> (.../node_modules/lock-diff/bin/lock-diff.js:17:21)
```