### PR TITLE
Support non-semver dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,10 +11,15 @@ function diff(oldLock, newLock) {
 
   Object.entries(newLock.dependencies).forEach(([name, { version }]) => {
     if (changes[name]) {
-      if (semver.eq(changes[name][0], version)) {
-        delete changes[name];
+      const oldVersion = changes[name][0]
+      const validSemver = semver.valid(oldVersion) && semver.valid(version);
+
+      if (validSemver && !semver.eq(oldVersion, version)) {
+        changes[name] = [oldVersion, version];
+      } else if (!validSemver && oldVersion !== version) {
+        changes[name] = [oldVersion, version];
       } else {
-        changes[name] = [changes[name][0], version];
+        delete changes[name];
       }
     } else {
       changes[name] = [null, version];
@@ -40,6 +45,8 @@ function printText(changes, options) {
   /* eslint-disable no-console */
 
   Object.entries(changes).forEach(([name, [oldVersion, newVersion]]) => {
+    const validSemver = semver.valid(oldVersion) && semver.valid(newVersion)
+
     if (!oldVersion) {
       if (options.color) {
         console.log(`${name} ${chalk.red('removed')}`);
@@ -52,7 +59,13 @@ function printText(changes, options) {
       } else {
         console.log(`${name} added`);
       }
-    } else if (!semver.eq(oldVersion, newVersion)) {
+    } else if (!validSemver && oldVersion !== newVersion) {
+      if (options.color) {
+        console.log(`${name} ${chalk.green(`${oldVersion} -> ${newVersion}`)}`);
+      } else {
+        console.log(`${name} ${oldVersion} -> ${newVersion}`);
+      }
+    } else if (validSemver && !semver.eq(oldVersion, newVersion)) {
       if (options.color) {
         const color = semver.gt(oldVersion, newVersion)
           ? chalk.red


### PR DESCRIPTION
Adds support for non-semver dependencies, e.g. when you've installed a fork:

```
"some-package": "git+https://git@github.com/path/to.git#some-branch"
```

Treats them as additions (`chalk.green`) if they change, remove them from the diff so long as the strings match.